### PR TITLE
add header sandwich for windows include

### DIFF
--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -7,6 +7,8 @@
 #include "GeneralProjectSettings.h"
 #include "LevelEditor.h"
 #include "Editor.h"
+
+#include "Windows/AllowWindowsPlatformTypes.h"
 #include <Windows.h>
 #include <iostream>
 #include <fstream>
@@ -469,3 +471,5 @@ void FWakaTimeForUE4Module::AddToolbarButton(FToolBarBuilder& Builder)
 #undef LOCTEXT_NAMESPACE
 
 IMPLEMENT_MODULE(FWakaTimeForUE4Module, WakaTimeForUE4)
+
+#include "Windows/HideWindowsPlatformTypes.h"


### PR DESCRIPTION
Wrap Windows.h functionality in WakaTimeForUE4.cpp with
```
#include "Windows/AllowWindowsPlatformTypes.h"
#include <Windows.h>
...
#include "Windows/HideWindowsPlatformTypes.h
```
Fixes the errors on TEXT macro redefinition in #4 