### PR TITLE
it's working, however there's something else failing after we check for whether `wakatime` exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ---
 
+#### If you're already using a WakaTime plugin (for example, in Visual Studio or whatever), you likely have `.wakatime` and `.wakatime.cfg` in your home directory. If you do, just put the plugin in its place and launch the engine, all should work without any additional configuration.
+ 
+
 Make sure you have Python, pip and wakatime installed and **available from cmd/terminal**.
 That means both installing it and adding it into your PATH variable.
 

--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -160,35 +160,37 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 
 	const char* commie = command.c_str();
 
-	system(commie);
+	//system(commie);
 
-	//bool success = CreateProcess(exe, // use cmd
-	//                             cmd, // the command
-	//                             nullptr, // Process handle not inheritable
-	//                             nullptr, // Thread handle not inheritable
-	//                             FALSE, // Set handle inheritance to FALSE
-	//                             CREATE_NO_WINDOW, // Dont open the console window
-	//                             nullptr, // Use parent's environment block
-	//                             nullptr, // Use parent's starting directory 
-	//                             &si, // Pointer to STARTUPINFO structure
-	//                             &pi); // Pointer to PROCESS_INFORMATION structure
+	//WinExec(commie, SW_HIDE);
+
+	bool success = CreateProcess(exe, // use cmd
+	                             cmd, // the command
+	                             nullptr, // Process handle not inheritable
+	                             nullptr, // Thread handle not inheritable
+	                             FALSE, // Set handle inheritance to FALSE
+	                             CREATE_NO_WINDOW, // Dont open the console window
+	                             nullptr, // Use parent's environment block
+	                             nullptr, // Use parent's starting directory 
+	                             &si, // Pointer to STARTUPINFO structure
+	                             &pi); // Pointer to PROCESS_INFORMATION structure
 
 	// Wait until process exits.
-	//WaitForSingleObject(pi.hProcess, INFINITE);
+	WaitForSingleObject(pi.hProcess, INFINITE);
 
 	// Close process and thread handles. 
-	//CloseHandle(pi.hProcess);
-	//CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	CloseHandle(pi.hThread);
 
-//	if (success)
-//	{
-//		UE_LOG(LogTemp, Warning, TEXT("WakaTime: Heartbeat successfully sent."));
-//	}
-//	else
-//	{
-//		UE_LOG(LogTemp, Error, TEXT("WakaTime: Heartbeat couldn't be sent."));
-//		UE_LOG(LogTemp, Error, TEXT("WakaTime: Error code = %d"), GetLastError());
-//	}
+	if (success)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("WakaTime: Heartbeat successfully sent."));
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("WakaTime: Heartbeat couldn't be sent."));
+		UE_LOG(LogTemp, Error, TEXT("WakaTime: Error code = %d"), GetLastError());
+	}
 }
 
 void SendHeartbeat(bool fileSave, FString filepath)

--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -116,7 +116,9 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 {
 	UE_LOG(LogTemp, Warning, TEXT("WakaTime: Sending Heartbeat"));
 
-	string command(" /C start /B wakatime --entity \"" + filePath + "\" ");
+	cmd / c "(help FOO > nul || exit 0) && where FOO > nul 2> nul"
+
+	string command(" /C start /B wakatime-cli.exe --entity \"" + filePath + "\" ");
 	if (apiKey != "")
 	{
 		command += "--key " + apiKey + " ";

--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -158,33 +158,37 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 	mbstowcs(wtext, command.c_str(), strlen(command.c_str()) + 1); //Plus null
 	LPWSTR cmd = wtext;
 
-	bool success = CreateProcess(exe, // use cmd
-	                             cmd, // the command
-	                             nullptr, // Process handle not inheritable
-	                             nullptr, // Thread handle not inheritable
-	                             FALSE, // Set handle inheritance to FALSE
-	                             CREATE_NO_WINDOW, // Dont open the console window
-	                             nullptr, // Use parent's environment block
-	                             nullptr, // Use parent's starting directory 
-	                             &si, // Pointer to STARTUPINFO structure
-	                             &pi); // Pointer to PROCESS_INFORMATION structure
+	const char* commie = command.c_str();
+
+	system(commie);
+
+	//bool success = CreateProcess(exe, // use cmd
+	//                             cmd, // the command
+	//                             nullptr, // Process handle not inheritable
+	//                             nullptr, // Thread handle not inheritable
+	//                             FALSE, // Set handle inheritance to FALSE
+	//                             CREATE_NO_WINDOW, // Dont open the console window
+	//                             nullptr, // Use parent's environment block
+	//                             nullptr, // Use parent's starting directory 
+	//                             &si, // Pointer to STARTUPINFO structure
+	//                             &pi); // Pointer to PROCESS_INFORMATION structure
 
 	// Wait until process exits.
-	WaitForSingleObject(pi.hProcess, INFINITE);
+	//WaitForSingleObject(pi.hProcess, INFINITE);
 
 	// Close process and thread handles. 
-	CloseHandle(pi.hProcess);
-	CloseHandle(pi.hThread);
+	//CloseHandle(pi.hProcess);
+	//CloseHandle(pi.hThread);
 
-	if (success)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("WakaTime: Heartbeat successfully sent."));
-	}
-	else
-	{
-		UE_LOG(LogTemp, Error, TEXT("WakaTime: Heartbeat couldn't be sent."));
-		UE_LOG(LogTemp, Error, TEXT("WakaTime: Error code = %d"), GetLastError());
-	}
+//	if (success)
+//	{
+//		UE_LOG(LogTemp, Warning, TEXT("WakaTime: Heartbeat successfully sent."));
+//	}
+//	else
+//	{
+//		UE_LOG(LogTemp, Error, TEXT("WakaTime: Heartbeat couldn't be sent."));
+//		UE_LOG(LogTemp, Error, TEXT("WakaTime: Error code = %d"), GetLastError());
+//	}
 }
 
 void SendHeartbeat(bool fileSave, FString filepath)
@@ -257,7 +261,7 @@ void FWakaTimeForUE4Module::StartupModule()
 		UE_LOG(LogTemp, Error, TEXT("WakaTime: No GEditor present"));
 	}
 
-	//WakaCommands::Register();
+	WakaCommands::Register();
 
 	PluginCommands = MakeShareable(new FUICommandList);
 	//PluginCommands->MapAction(

--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -116,9 +116,19 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 {
 	UE_LOG(LogTemp, Warning, TEXT("WakaTime: Sending Heartbeat"));
 
-	cmd / c "(help FOO > nul || exit 0) && where FOO > nul 2> nul"
+	string command;
 
-	string command(" /C start /B wakatime-cli.exe --entity \"" + filePath + "\" ");
+
+	//look for an external command called 'wakatime'. if it exists, use the pure `wakatime` command, but if it doesn't, call the executable by its full-name
+	// WARN: have your wakatime-cli dir in your $PATH
+	if(system("where wakatime") == 0) //if we found an external command called 'wakatime'
+	{
+		command = (" /c start /b wakatime --entity \"" + filePath + "\" ");
+	} else 
+	{ 
+		command = (" /c start /b wakatime-cli.exe --entity \"" + filePath + "\" ");
+	}
+
 	if (apiKey != "")
 	{
 		command += "--key " + apiKey + " ";
@@ -247,13 +257,13 @@ void FWakaTimeForUE4Module::StartupModule()
 		UE_LOG(LogTemp, Error, TEXT("WakaTime: No GEditor present"));
 	}
 
-	WakaCommands::Register();
+	//WakaCommands::Register();
 
 	PluginCommands = MakeShareable(new FUICommandList);
-	PluginCommands->MapAction(
-		WakaCommands::Get().TestCommand,
-		FExecuteAction::CreateRaw(this, &FWakaTimeForUE4Module::OpenSettingsWindow)
-	);
+	//PluginCommands->MapAction(
+	//	WakaCommands::Get().TestCommand,
+	//	FExecuteAction::CreateRaw(this, &FWakaTimeForUE4Module::OpenSettingsWindow)
+	//);
 
 	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
 

--- a/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
+++ b/Source/WakaTimeForUE4/Private/WakaTimeForUE4.cpp
@@ -86,11 +86,19 @@ FReply FWakaTimeForUE4Module::SaveData()
 {
 	UE_LOG(LogTemp, Warning, TEXT("WakaTime: Saving settings"));
 	apiKey = TCHAR_TO_UTF8(*(apiKeyBlock.Get().GetText().ToString()));
-	std::ofstream saveFile;
-	saveFile.open("wakatimeSaveData.txt");
-	saveFile << position << '\n';
-	saveFile << apiKey;
-	saveFile.close();
+	const char* homedrive = getenv("HOMEDRIVE");
+	const char* homepath = getenv("HOMEPATH");
+	std::string configFileDir = std::string(homedrive) + homepath + "/.wakatime.cfg";
+	//std::ofstream saveFile;
+	std::ofstream configFile;
+	//saveFile.open("wakatimeSaveData.txt");
+	configFile.open(configFileDir);
+	configFile << position << '\n';
+	configFile << apiKey;
+	configFile.close();
+	//saveFile << position << '\n';
+	//saveFile << apiKey;
+	//saveFile.close();
 	SettingsWindow.Get().RequestDestroyWindow();
 	return FReply::Handled();
 }
@@ -158,7 +166,7 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 	mbstowcs(wtext, command.c_str(), strlen(command.c_str()) + 1); //Plus null
 	LPWSTR cmd = wtext;
 
-	const char* commie = command.c_str();
+	//const char* commie = command.c_str(); // I didn't know how to name this var since both cmd and command were used XD
 
 	//system(commie);
 
@@ -169,7 +177,7 @@ void SendHeartbeat(bool fileSave, std::string filePath)
 	                             nullptr, // Process handle not inheritable
 	                             nullptr, // Thread handle not inheritable
 	                             FALSE, // Set handle inheritance to FALSE
-	                             CREATE_NO_WINDOW, // Dont open the console window
+	                             CREATE_NO_WINDOW, // Don't open the console window // this doesn't seem to work, at least on my machine
 	                             nullptr, // Use parent's environment block
 	                             nullptr, // Use parent's starting directory 
 	                             &si, // Pointer to STARTUPINFO structure
@@ -209,7 +217,15 @@ void FWakaTimeForUE4Module::StartupModule()
 
 
 	std::string line;
-	std::ifstream infile("wakatimeSaveData.txt");
+	const char* homedrive = getenv("HOMEDRIVE");
+	const char* homepath = getenv("HOMEPATH");
+	std::string configFileDir = std::string(homedrive) + homepath + "/.wakatime.cfg";
+	std::ifstream infile(configFileDir);
+
+	if(infile.is_open())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("We've opened the infile"));
+	}
 
 	if (std::getline(infile, line))
 	{


### PR DESCRIPTION
I believe that we should call the binary directly and without the use of cmd, just like we would in Linux.

### Please test this before merging, as it crashes my engine, so just in case.
The problem is very likely with the use of `cmd`. We need to figure out a way around it. Perhaps just use `system` or the Windows native APIs to call the binary directly every time we want to push a heartbeat out. This way it would work basically on the same principle as Linux wakatime extensions.

I found out that the root of the problem is not with `cmd`, however all should be working with the latest commit, including the changed config file.