### PR TITLE
fix: reduce log pollution

### DIFF
--- a/Source/WakaTimeForUE/Private/WakaTimeHelpers.cpp
+++ b/Source/WakaTimeForUE/Private/WakaTimeHelpers.cpp
@@ -23,7 +23,7 @@ bool FWakaTimeHelpers::RunCommand(std::string CommandToRun, bool bRequireNonZero
 		CommandToRun = " /c start /b " + CommandToRun;
 	}
 
-	UE_LOG(LogTemp, Warning, TEXT("Running command: %s"), *FString(UTF8_TO_TCHAR(CommandToRun.c_str())));
+	UE_LOG(LogTemp, Log, TEXT("WakaTime: Running command: %s"), *FString(UTF8_TO_TCHAR(CommandToRun.c_str())));
 
 	STARTUPINFO Startupinfo;
 	PROCESS_INFORMATION Process_Information;


### PR DESCRIPTION
I don't think this shouldn't be a warning, since it's the default and intended behavior.