### PR TITLE
Various improvements

### DIFF
--- a/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
+++ b/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
@@ -11,6 +11,7 @@
 #include <activation.h>
 #include <fstream>
 
+#include "BlueprintEditorModule.h"
 #include "Interfaces/IPluginManager.h"
 #include "UObject/ObjectSaveContext.h"
 
@@ -20,8 +21,10 @@ using namespace std;
 
 // Global variables
 string GAPIKey("");
+string GAPIUrl("");
 string GBaseCommand("");
 string GUserProfile;
+string GProjectPath;
 string GWakatimeArchitecture;
 string GWakaCliVersion;
 
@@ -33,11 +36,16 @@ FDelegateHandle AddLevelToWorldHandle;
 FDelegateHandle PostSaveWorldHandle;
 FDelegateHandle GPostPieStartedHandle;
 FDelegateHandle GPrePieEndedHandle;
-FDelegateHandle BlueprintCompiledHandle;
+FDelegateHandle OnBlueprintPreCompileHandle;
+FDelegateHandle OnEditorInitializedHandle;
+FDelegateHandle OnAssetOpenedInEditorHandle;
+FDelegateHandle OnAssetClosedInEditorHandle;
 
 // UI Elements
 TSharedRef<SEditableTextBox> GAPIKeyBlock = SNew(SEditableTextBox)
 .Text(FText::FromString(FString(UTF8_TO_TCHAR(GAPIKey.c_str())))).MinDesiredWidth(500);
+TSharedRef<SEditableTextBox> GAPIUrlBlock = SNew(SEditableTextBox)
+.Text(FText::FromString(FString(UTF8_TO_TCHAR(GAPIUrl.c_str())))).MinDesiredWidth(500);
 TSharedRef<SWindow> SettingsWindow = SNew(SWindow);
 TSharedPtr<FSlateStyleSet> StyleSetInstance = nullptr;
 
@@ -49,10 +57,10 @@ void FWakaTimeForUEModule::StartupModule()
 {
 	AssignGlobalVariables();
 
+	FString WakatimeCliFilePath = FString(GUserProfile.c_str()) + TEXT("\\.wakatime\\") + FString(GWakaCliVersion.c_str());
+	
 	// testing for "wakatime-cli.exe" which is used by most IDEs
-	if (FWakaTimeHelpers::RunCmdCommand(
-		"where /r " + string(GUserProfile) + "\\.wakatime\\" + GWakaCliVersion,
-		true))
+	if (FPlatformFileManager::Get().GetPlatformFile().FileExists(*WakatimeCliFilePath))
 	{
 		UE_LOG(LogWakaTime, Log, TEXT("Found IDE wakatime-cli"));
 		GBaseCommand = (string(GUserProfile) + "\\.wakatime\\" + GWakaCliVersion);
@@ -68,7 +76,7 @@ void FWakaTimeForUEModule::StartupModule()
 		{
 			FWakaTimeHelpers::RunCmdCommand("mkdir " + FolderPath, false, INFINITE);
 		}
-		DownloadWakatimeCli(string(GUserProfile) + "/.wakatime/wakatime-cli/" + GWakaCliVersion);
+		DownloadWakatimeCli(string(GUserProfile) + "\\.wakatime\\wakatime-cli\\" + GWakaCliVersion);
 	}
 	// TheAshenWolf(Wakatime-cli.exe is not in the path by default, which is why we have to use the user path)
 
@@ -79,7 +87,7 @@ void FWakaTimeForUEModule::StartupModule()
 		FSlateStyleRegistry::RegisterSlateStyle(*StyleSetInstance);
 	}
 
-	string ConfigFileDir = string(GUserProfile) + "/.wakatime.cfg";
+	string ConfigFileDir = string(GUserProfile) + "\\.wakatime.cfg";
 	HandleStartupApiCheck(ConfigFileDir);
 
 	// Add Listeners
@@ -95,21 +103,11 @@ void FWakaTimeForUEModule::StartupModule()
 #else// TheAshenWolf(PostSaveWorld is deprecated as of UE5)
 	PostSaveWorldHandle = FEditorDelegates::PostSaveWorld.AddRaw(this, &FWakaTimeForUEModule::OnPostSaveWorld);
 #endif
-
-
-	
 	
 	GPostPieStartedHandle = FEditorDelegates::PostPIEStarted.AddRaw(this, &FWakaTimeForUEModule::OnPostPieStarted);
 	GPrePieEndedHandle = FEditorDelegates::PrePIEEnded.AddRaw(this, &FWakaTimeForUEModule::OnPrePieEnded);
-	if (GEditor)
-	{
-		BlueprintCompiledHandle = GEditor->OnBlueprintCompiled().AddRaw(
-			this, &FWakaTimeForUEModule::OnBlueprintCompiled);
-	}
-	else
-	{
-		UE_LOG(LogWakaTime, Error, TEXT("No GEditor present"));
-	}
+	
+	OnEditorInitializedHandle = FEditorDelegates::OnEditorInitialized.AddRaw(this, &FWakaTimeForUEModule::OnEditorInitialized);
 
 	FWakaCommands::Register();
 
@@ -148,9 +146,16 @@ void FWakaTimeForUEModule::ShutdownModule()
 #endif
 	FEditorDelegates::PostPIEStarted.Remove(GPostPieStartedHandle);
 	FEditorDelegates::PrePIEEnded.Remove(GPrePieEndedHandle);
+	
 	if (GEditor)
 	{
-		GEditor->OnBlueprintCompiled().Remove(BlueprintCompiledHandle);
+		GEditor->OnBlueprintPreCompile().Remove(OnBlueprintPreCompileHandle);
+
+		if (UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>())
+		{
+			AssetEditorSubsystem->OnAssetOpenedInEditor().Remove(OnAssetOpenedInEditorHandle);
+			AssetEditorSubsystem->OnAssetClosedInEditor().Remove(OnAssetClosedInEditorHandle);
+		}
 	}
 }
 
@@ -181,12 +186,15 @@ void FWakaTimeForUEModule::AssignGlobalVariables()
 	WCHAR BufferW[256];
 	GWakatimeArchitecture = GetSystemWow64DirectoryW(BufferW, 256) == 0 ? "386" : "amd64";
 	GWakaCliVersion = "wakatime-cli-windows-" + GWakatimeArchitecture + ".exe";
+	
+	GProjectPath = TCHAR_TO_UTF8(*FPaths::ProjectDir().Replace(TEXT("/"), TEXT("\\")));
 }
 
 void FWakaTimeForUEModule::HandleStartupApiCheck(string ConfigFilePath)
 {
 	string Line;
 	bool bFoundApiKey = false;
+	bool bFoundApiUrl = false;
 
 	if (!FWakaTimeHelpers::PathExists(ConfigFilePath))
 	// if there is no .wakatime.cfg, open the settings window straight up
@@ -203,15 +211,28 @@ void FWakaTimeForUEModule::HandleStartupApiCheck(string ConfigFilePath)
 		{
 			GAPIKey = Line.substr(Line.find(" = ") + 3); // Pozitrone(Extract only the api key from the line);
 			GAPIKeyBlock.Get().SetText(FText::FromString(FString(UTF8_TO_TCHAR(GAPIKey.c_str()))));
-			ConfigFile.close();
 			bFoundApiKey = true;
-			break;
+		}
+
+		if (Line.find("api_url") != string::npos)
+		{
+			GAPIUrl = Line.substr(Line.find(" = ") + 3); // Pozitrone(Extract only the api key from the line);
+			GAPIUrlBlock.Get().SetText(FText::FromString(FString(UTF8_TO_TCHAR(GAPIUrl.c_str()))));
+			bFoundApiUrl = true;
 		}
 	}
+
+	ConfigFile.close();
 
 	if (!bFoundApiKey)
 	{
 		UE_LOG(LogWakaTime, Warning, TEXT("API key not found in config file"));
+		OpenSettingsWindow(); // if key was not found, open the settings
+	}
+
+	if (!bFoundApiUrl)
+	{
+		UE_LOG(LogWakaTime, Warning, TEXT("API url not found in config file"));
 		OpenSettingsWindow(); // if key was not found, open the settings
 	}
 }
@@ -239,7 +260,7 @@ void FWakaTimeForUEModule::DownloadWakatimeCli(string CliPath)
 	{
 		UE_LOG(LogWakaTime, Log, TEXT("Successfully downloaded wakatime-cli.zip"));
 		bool bSuccessUnzip = FWakaTimeHelpers::UnzipArchive(LocalZipFilePath,
-		                                                    string(GUserProfile) + "/.wakatime");
+		                                                    string(GUserProfile) + "\\.wakatime");
 
 		if (bSuccessUnzip) UE_LOG(LogWakaTime, Log, TEXT("Successfully extracted wakatime-cli."));
 	}
@@ -274,7 +295,6 @@ TSharedRef<FSlateStyleSet> FWakaTimeForUEModule::CreateToolbarIcon()
 	TSharedRef<FSlateStyleSet> Style = MakeShareable(new FSlateStyleSet("WakaTime2DStyle"));
 
 	FString ResourcesDirectory = IPluginManager::Get().FindPlugin(TEXT("WakaTimeForUE"))->GetBaseDir() + "/Resources";
-	UE_LOG(LogWakaTime, Log, TEXT("%s"), *ResourcesDirectory);
 
 	Style->SetContentRoot(ResourcesDirectory);
 	Style->Set("mainIcon", new FSlateImageBrush(ResourcesDirectory + "/Icon128.png", FVector2D(40, 40),
@@ -319,6 +339,19 @@ void FWakaTimeForUEModule::OpenSettingsWindow()
 			[
 				GAPIKeyBlock
 			]
+			+ SVerticalBox::Slot()
+			.HAlign(HAlign_Left)
+			.VAlign(VAlign_Top)
+			[
+				SNew(STextBlock)
+				.Text(FText::FromString(TEXT("Your api url:"))).MinDesiredWidth(500)
+			]
+			+ SVerticalBox::Slot()
+				.HAlign(HAlign_Center)
+				.VAlign(VAlign_Center)
+			[
+				GAPIUrlBlock
+			]
 		]
 		+ SVerticalBox::Slot()
 		  .HAlign(HAlign_Center)
@@ -354,6 +387,9 @@ FReply FWakaTimeForUEModule::SaveData()
 	string APIKeyBase = TCHAR_TO_UTF8(*(GAPIKeyBlock.Get().GetText().ToString()));
 	GAPIKey = APIKeyBase.substr(APIKeyBase.find(" = ") + 1);
 
+	string APIUrlBase = TCHAR_TO_UTF8(*(GAPIUrlBlock.Get().GetText().ToString()));
+	GAPIUrl = APIUrlBase.substr(APIUrlBase.find(" = ") + 1);
+
 	string ConfigFileDir = string(GUserProfile) + "/.wakatime.cfg";
 	fstream ConfigFile(ConfigFileDir);
 
@@ -363,6 +399,7 @@ FReply FWakaTimeForUEModule::SaveData()
 		// Pozitrone(Create the file if it does not exist) and write the data in it
 		ConfigFile << "[settings]" << '\n';
 		ConfigFile << "api_key = " << GAPIKey;
+		ConfigFile << "api_url = " << GAPIUrl;
 		ConfigFile.close();
 
 		SettingsWindow.Get().RequestDestroyWindow();
@@ -372,12 +409,17 @@ FReply FWakaTimeForUEModule::SaveData()
 	TArray<string> Data;
 	string TempLine;
 	bool bFoundKey = false;
+	bool bFoundUrl = false;
 	while (getline(ConfigFile, TempLine))
 	{
 		if (TempLine.find("api_key") != string::npos)
 		{
 			Data.Add("api_key = " + GAPIKey); // if key was found, add the rewritten value to the data set
 			bFoundKey = true;
+		} else if(TempLine.find("api_url") != string::npos)
+		{
+			Data.Add("api_url = " + GAPIUrl); // if key was found, add the rewritten value to the data set
+			bFoundUrl = true;
 		}
 		else
 		{
@@ -386,12 +428,13 @@ FReply FWakaTimeForUEModule::SaveData()
 	}
 	ConfigFile.close();
 
-	if (!bFoundKey)
+	if (!bFoundKey || !bFoundUrl)
 	{
 		// There is no key present, add it
 		ConfigFile.open(ConfigFileDir, fstream::out);
 		ConfigFile << "[settings]" << '\n';
 		ConfigFile << "api_key = " << GAPIKey;
+		ConfigFile << "api_url = " << GAPIUrl;
 		ConfigFile.close();
 	}
 	else
@@ -410,22 +453,26 @@ FReply FWakaTimeForUEModule::SaveData()
 }
 
 // Lifecycle methods
-void FWakaTimeForUEModule::SendHeartbeat(bool bFileSave, string FilePath, string Activity)
+void FWakaTimeForUEModule::SendHeartbeat(bool bFileSave, string Activity, string EntityType, FString Entity, string Language)
 {
 	UE_LOG(LogWakaTime, Log, TEXT("Sending Heartbeat"));
 
 	string Command = GBaseCommand;
 
-	Command += " --entity \"" + GetProjectName() + "\" ";
+	Command += " --config " + string(GUserProfile) + "\\.wakatime.cfg ";
+	Command += "--log-file " + string(GUserProfile) + "\\.wakatime\\wakatime.log ";
 
-	if (GAPIKey != "")
+	if(GAPIUrl != "")
 	{
-		Command += "--key " + GAPIKey + " ";
+		Command += "--api-url " + GAPIUrl + " ";
 	}
 
 	Command += "--project \"" + GetProjectName() + "\" ";
-	Command += "--entity-type \"app\" ";
-	Command += "--language \"Unreal Engine\" ";
+	Command += "--project-folder " + GProjectPath + " ";
+	string EntityStr = TCHAR_TO_UTF8(*Entity.Replace(TEXT("/"), TEXT("\\")));
+	Command += "--entity " + EntityStr + " ";
+	Command += "--entity-type \"" + EntityType + "\" ";
+	Command += "--language \"" + Language + "\" ";
 	Command += "--plugin \"unreal-wakatime/1.2.5\" "; // Update this with the plugin version from .uplugin (Unreal Plugin Settings) (Avoid Hardcoding it here) TODO
 	Command += "--category " + Activity + " ";
 
@@ -437,7 +484,7 @@ void FWakaTimeForUEModule::SendHeartbeat(bool bFileSave, string FilePath, string
 	bool bSuccess = false;
 	try
 	{
-		bSuccess = FWakaTimeHelpers::RunCmdCommand(Command, false, INFINITE, true);
+		bSuccess = FWakaTimeHelpers::RunPowershellCommand(Command, false, INFINITE, true);
 	}
 	catch (int Err)
 	{
@@ -459,28 +506,28 @@ void FWakaTimeForUEModule::SendHeartbeat(bool bFileSave, string FilePath, string
 // Event methods
 void FWakaTimeForUEModule::OnNewActorDropped(const TArray<UObject*>& Objects, const TArray<AActor*>& Actors)
 {
-	SendHeartbeat(false, GetProjectName(), "designing");
+	SendHeartbeat(false, "designing", "app", "Unreal Editor", "Unreal Editor");
 }
 
 void FWakaTimeForUEModule::OnDuplicateActorsEnd()
 {
-	SendHeartbeat(false, GetProjectName(), "designing");
+	SendHeartbeat(false, "designing", "app", "Unreal Editor", "Unreal Editor");
 }
 
 void FWakaTimeForUEModule::OnDeleteActorsEnd()
 {
-	SendHeartbeat(false, GetProjectName(), "designing");
+	SendHeartbeat(false, "designing", "app", "Unreal Editor", "Unreal Editor");
 }
 
 void FWakaTimeForUEModule::OnAddLevelToWorld(ULevel* Level)
 {
-	SendHeartbeat(false, GetProjectName(), "designing");
+	SendHeartbeat(false, "designing", "app", "Unreal Editor", "Unreal Editor");
 }
 
 #if ENGINE_MAJOR_VERSION == 5
 	void FWakaTimeForUEModule::OnPostSaveWorld(UWorld* World, FObjectPostSaveContext Context)
 	{
-		SendHeartbeat(true, GetProjectName(), "designing");
+		SendHeartbeat(true, "designing", "app", "Unreal Editor", "Unreal Editor");
 }
 #else
 	void FWakaTimeForUEModule::OnPostSaveWorld(uint32 SaveFlags, UWorld* World, bool bSucces)
@@ -491,19 +538,65 @@ void FWakaTimeForUEModule::OnAddLevelToWorld(ULevel* Level)
 
 void FWakaTimeForUEModule::OnPostPieStarted(bool bIsSimulating)
 {
-	SendHeartbeat(false, GetProjectName(), "debugging");
+	SendHeartbeat(false, "debugging", "app", "Unreal Editor", "Unreal Editor");
 }
 
 void FWakaTimeForUEModule::OnPrePieEnded(bool bIsSimulating)
 {
-	SendHeartbeat(true, GetProjectName(), "debugging");
+	SendHeartbeat(true, "debugging", "app", "Unreal Editor", "Unreal Editor");
 }
 
-void FWakaTimeForUEModule::OnBlueprintCompiled()
+void FWakaTimeForUEModule::OnBlueprintPreCompile(UBlueprint* Blueprint)
 {
-	SendHeartbeat(true, GetProjectName(), "coding");
+	auto Found = OpenedBPs.ContainsByPredicate([Blueprint](const TSharedRef<FString>& BPName)
+		{
+			return *BPName == Blueprint->GetName();
+		});
+	
+	if(!Found) return;
+
+	FString PackageName = Blueprint->GetOutermost()->GetName();
+	FString FilePath = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+ 
+	SendHeartbeat(true, "coding", "file", TCHAR_TO_UTF8(*FilePath), "Blueprints");
 }
 
+void FWakaTimeForUEModule::OnAssetOpened(UObject* Asset, IAssetEditorInstance* AssetEditor)
+{
+	if(!Asset->IsA<UBlueprint>()) return;
+	
+	OpenedBPs.Add(MakeShared<FString>(Asset->GetName()));
+}
+
+void FWakaTimeForUEModule::OnAssetClosed(UObject* Asset, IAssetEditorInstance* AssetEditor)
+{
+	if(!Asset->IsA<UBlueprint>()) return;
+	
+	OpenedBPs.RemoveAll([Asset](const TSharedRef<FString>& BPName)
+	{
+		return *BPName == Asset->GetName();
+	});
+}
+
+void FWakaTimeForUEModule::OnEditorInitialized(double TimeToInitializeEditor)
+{
+	if (GEditor)
+	{
+		if (UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>())
+		{
+			OnAssetOpenedInEditorHandle = AssetEditorSubsystem->OnAssetOpenedInEditor().AddRaw(this, &FWakaTimeForUEModule::OnAssetOpened);
+			OnAssetClosedInEditorHandle = AssetEditorSubsystem->OnAssetClosedInEditor().AddRaw(this, &FWakaTimeForUEModule::OnAssetClosed);
+		}
+		
+		OnBlueprintPreCompileHandle = GEditor->OnBlueprintPreCompile().AddRaw(this, &FWakaTimeForUEModule::OnBlueprintPreCompile);
+	}
+	else
+	{
+		UE_LOG(LogWakaTime, Error, TEXT("No GEditor present"));
+	}
+
+	FEditorDelegates::OnEditorInitialized.Remove(OnEditorInitializedHandle);
+}
 
 #undef LOCTEXT_NAMESPACE
 

--- a/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
+++ b/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
@@ -39,7 +39,7 @@ FDelegateHandle GPostPieStartedHandle;
 FDelegateHandle GPrePieEndedHandle;
 FDelegateHandle OnBlueprintPreCompileHandle;
 FDelegateHandle OnEditorInitializedHandle;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 FDelegateHandle OnAssetOpenedInEditorHandle;
 FDelegateHandle OnAssetClosedInEditorHandle;
 #endif
@@ -154,7 +154,7 @@ void FWakaTimeForUEModule::ShutdownModule()
 	{
 		GEditor->OnBlueprintPreCompile().Remove(OnBlueprintPreCompileHandle);
 
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 		if (UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>())
 		{
 			AssetEditorSubsystem->OnAssetOpenedInEditor().Remove(OnAssetOpenedInEditorHandle);
@@ -594,7 +594,7 @@ void FWakaTimeForUEModule::OnPrePieEnded(bool bIsSimulating)
 
 void FWakaTimeForUEModule::OnBlueprintPreCompile(UBlueprint* Blueprint)
 {
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 	auto Found = OpenedBPs.ContainsByPredicate([Blueprint](const TSharedRef<FString>& BPName)
 		{
 			return *BPName == Blueprint->GetName();
@@ -611,7 +611,7 @@ void FWakaTimeForUEModule::OnBlueprintPreCompile(UBlueprint* Blueprint)
 #endif
 }
 
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 void FWakaTimeForUEModule::OnAssetOpened(UObject* Asset, IAssetEditorInstance* AssetEditor)
 {
 	if(!Asset->IsA<UBlueprint>()) return;
@@ -634,7 +634,7 @@ void FWakaTimeForUEModule::OnEditorInitialized(double TimeToInitializeEditor)
 {
 	if (GEditor)
 	{
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 		if (UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>())
 		{
 			OnAssetOpenedInEditorHandle = AssetEditorSubsystem->OnAssetOpenedInEditor().AddRaw(this, &FWakaTimeForUEModule::OnAssetOpened);

--- a/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
+++ b/Source/WakaTimeForUE/Private/WakaTimeForUE.cpp
@@ -431,7 +431,7 @@ FReply FWakaTimeForUEModule::SaveData()
 		return FReply::Handled();
 	}
 
-	TMap<FString, FString> Data;
+	map<string, string> Data;
 	
 	string TempLine;
 	while (getline(ConfigFile, TempLine)) // RedKitsune(Turn entire ini file into TMap);
@@ -442,14 +442,14 @@ FReply FWakaTimeForUEModule::SaveData()
 		string Key = TempLine.substr(0, Pos);
 		string Value = TempLine.substr(Pos + std::strlen(" = "));
 
-		Data.Add(UTF8_TO_TCHAR(Key.c_str()), UTF8_TO_TCHAR(Value.c_str()));
+		Data.insert(std::make_pair(Key, Value));
 	}
 	ConfigFile.close();
 
 	bool bIsDirty = false;
 	
-	bIsDirty = UpdateIniEntry(Data, "api_key", UTF8_TO_TCHAR(GAPIKey.c_str()));
-	bIsDirty = UpdateIniEntry(Data, "api_url", UTF8_TO_TCHAR(GAPIUrl.c_str()));
+	UpdateIniEntry(bIsDirty, Data, "api_key", GAPIKey);
+	UpdateIniEntry(bIsDirty, Data, "api_url", GAPIUrl);
 	
 	if(bIsDirty)
 	{
@@ -461,7 +461,7 @@ FReply FWakaTimeForUEModule::SaveData()
 		
 		for(auto kvp : Data)
 		{
-			ConfigFile << TCHAR_TO_UTF8(*kvp.Key) << " = " << TCHAR_TO_UTF8(*kvp.Value) << '\n';
+			ConfigFile << kvp.first << " = " << kvp.second << '\n';
 		}
 
 		ConfigFile.close();
@@ -471,26 +471,26 @@ FReply FWakaTimeForUEModule::SaveData()
 	return FReply::Handled();
 }
 
-bool FWakaTimeForUEModule::UpdateIniEntry(TMap<FString, FString>& Data, FString Key, FString Value)
+void FWakaTimeForUEModule::UpdateIniEntry(bool& bIsDirty, map<string, string>& Data, string Key, string Value)
 {
-	if(Value.IsEmpty())
+	if(Value.empty())
 	{
-		if(Data.Contains(Key))
+		if(Data.contains(Key))
 		{
-			Data.Remove(Key);
-			return true;
-		} else return false;
+			Data.erase(Key);
+			bIsDirty =  true;
+		}
 	} else
 	{
-		if(!Data.Contains(Key))
+		if(!Data.contains(Key))
 		{
-			Data.Add(Key, Value);
-			return true;
-		} else if(!Data[Key].Equals(Value))
+			Data.insert(std::make_pair(Key, Value));
+			bIsDirty =  true;
+		} else if(!Data[Key].compare(Value))
 		{
 			Data[Key] = Value;
-			return true;
-		} else return false;
+			bIsDirty =  true;
+		}
 	}
 }
 

--- a/Source/WakaTimeForUE/Private/WakaTimeHelpers.cpp
+++ b/Source/WakaTimeForUE/Private/WakaTimeHelpers.cpp
@@ -3,6 +3,8 @@
 #include <activation.h>
 #include <string>
 
+#include "WakaTimeForUE.h"
+
 bool FWakaTimeHelpers::PathExists(const std::string& Path)
 {
 	struct stat Buffer;
@@ -59,7 +61,7 @@ bool FWakaTimeHelpers::RunCommand(std::string CommandToRun, bool bRequireNonZero
 	}
 
 	WaitForSingleObject(Process_Information.hProcess, WaitMs);
-
+	
 	CloseHandle(Process_Information.hThread);
 	CloseHandle(Process_Information.hProcess);
 
@@ -81,8 +83,7 @@ bool FWakaTimeHelpers::RunCmdCommand(std::string CommandToRun, bool bRequireNonZ
                                      std::string Directory)
 {
 	return RunCommand(CommandToRun, bRequireNonZeroProcess, "C:\\Windows\\System32\\cmd.exe", WaitMs,
-	                  bRunPure,
-	                  Directory);
+	                  bRunPure, Directory);
 }
 
 

--- a/Source/WakaTimeForUE/Public/WakaTimeForUE.h
+++ b/Source/WakaTimeForUE/Public/WakaTimeForUE.h
@@ -84,7 +84,7 @@ public:
 	/// <param name="bFileSave"> whether to attach the file that is being worked on </param>
 	/// <param name="FilePath"> path to the current file that is being edited </param>
 	/// <param name="Activity"> activity being performed by the user while sending the heartbeat; e.g. coding, designing, debugging, etc. </param>
-	void SendHeartbeat(bool bFileSave, std::string FilePath, std::string Activity);
+	void SendHeartbeat(bool bFileSave, std::string Activity, std::string EntityType, FString Entity, std::string Language);
 
 
 	// Event methods
@@ -129,11 +129,27 @@ public:
 	void OnPrePieEnded(bool bIsSimulating);
 
 	/// <summary>
-	///	Event called when blueprint is compiled
+	///	Event called prior to blueprint compiling
 	/// </summary>
-	void OnBlueprintCompiled();
+	void OnBlueprintPreCompile(UBlueprint* Blueprint);
+	
+	/// <summary>
+	///	Event called when editor window is initialized
+	/// </summary>
+	void OnEditorInitialized(double TimeToInitializeEditor);
+
+	/// <summary>
+	///	Event called when asset window is opened
+	/// </summary>
+	void OnAssetOpened(UObject* Asset, IAssetEditorInstance* AssetEditor);
+
+	/// <summary>
+	///	Event called when asset window is closed
+	/// </summary>
+	void OnAssetClosed(UObject* Asset, IAssetEditorInstance* AssetEditor);
 
 	TSharedPtr<FUICommandList> PluginCommands;
+	TArray<TSharedRef<FString>> OpenedBPs;
 };
 
 class FWakaCommands : public TCommands<FWakaCommands>

--- a/Source/WakaTimeForUE/Public/WakaTimeForUE.h
+++ b/Source/WakaTimeForUE/Public/WakaTimeForUE.h
@@ -152,7 +152,7 @@ public:
 	/// </summary>
 	void OnEditorInitialized(double TimeToInitializeEditor);
 
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 	/// <summary>
 	///	Event called when asset window is opened
 	/// </summary>
@@ -165,7 +165,7 @@ public:
 #endif
 
 	TSharedPtr<FUICommandList> PluginCommands;
-#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4 // RedTheKitsune(OnAssetClosedInEditor is not available in <UE5.4, so blueprint name tracking will not work properly)
 	TArray<TSharedRef<FString>> OpenedBPs;
 #endif
 };

--- a/Source/WakaTimeForUE/Public/WakaTimeForUE.h
+++ b/Source/WakaTimeForUE/Public/WakaTimeForUE.h
@@ -38,6 +38,12 @@ public:
 	void HandleStartupApiCheck(std::string ConfigFilePath);
 
 	/// <summary>
+	///	Checks whether the wakatime config file exists and includes the api_key
+	/// </summary>
+	/// <param name="ConfigFilePath"> Path to the config file directory</param>
+	void ReadConfig(std::string ConfigFilePath, bool& bFoundApiKey, bool& bFoundApiUrl);
+
+	/// <summary>
 	///	Checks if Wakatime exists, if not, downloads it using Powershell
 	/// </summary>
 	/// <param name="CliPath"> Path to the wakatime exe file </param>
@@ -64,7 +70,12 @@ public:
 	void AddToolbarButton(FToolBarBuilder& Builder);
 
 	/// <summary>
-	///	Called when the toolbar icon is clicked; Opens the Slate window
+	///	Called when the toolbar icon is clicked; Reads config and opens the Slate window
+	/// </summary>
+	void OpenSettingsWindowFromUI();
+	
+	/// <summary>
+	///	Opens the Slate window
 	/// </summary>
 	void OpenSettingsWindow();
 
@@ -73,6 +84,8 @@ public:
 	///	Saves the entered api key into the wakatime.cfg file
 	/// </summary>
 	FReply SaveData();
+
+	bool UpdateIniEntry(TMap<FString, FString>& Data, FString Key, FString Value);
 
 
 	// Lifecycle methods

--- a/Source/WakaTimeForUE/Public/WakaTimeForUE.h
+++ b/Source/WakaTimeForUE/Public/WakaTimeForUE.h
@@ -152,6 +152,7 @@ public:
 	/// </summary>
 	void OnEditorInitialized(double TimeToInitializeEditor);
 
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
 	/// <summary>
 	///	Event called when asset window is opened
 	/// </summary>
@@ -161,9 +162,12 @@ public:
 	///	Event called when asset window is closed
 	/// </summary>
 	void OnAssetClosed(UObject* Asset, IAssetEditorInstance* AssetEditor);
+#endif
 
 	TSharedPtr<FUICommandList> PluginCommands;
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
 	TArray<TSharedRef<FString>> OpenedBPs;
+#endif
 };
 
 class FWakaCommands : public TCommands<FWakaCommands>

--- a/Source/WakaTimeForUE/Public/WakaTimeForUE.h
+++ b/Source/WakaTimeForUE/Public/WakaTimeForUE.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <map>
 #include <Runtime/SlateCore/Public/Styling/SlateStyle.h>
 #include "EditorStyleSet.h"
 
@@ -85,7 +86,7 @@ public:
 	/// </summary>
 	FReply SaveData();
 
-	bool UpdateIniEntry(TMap<FString, FString>& Data, FString Key, FString Value);
+	void UpdateIniEntry(bool& bIsDirty, std::map<std::string, std::string>& Data, std::string Key, std::string Value);
 
 
 	// Lifecycle methods

--- a/WakaTimeForUE.uplugin
+++ b/WakaTimeForUE.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 10205,
-	"VersionName": "1.2.5",
+	"VersionName": "1.2.6",
 	"FriendlyName": "WakaTimeForUE",
 	"Description": "WakaTime plugin for Unreal Engine. Contributions are welcome",
 	"Category": "Other",

--- a/WakaTimeForUE.uplugin
+++ b/WakaTimeForUE.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://github.com/TheAshenWolf/WakaTimeForUE",
 	"MarketplaceURL": "",
 	"SupportURL": "https://github.com/TheAshenWolf/WakaTimeForUE/issues",
-	"EngineVersion": "5.3.0",
+	"EngineVersion": "ANY_VERSION",
 	"EnabledByDefault": true,
 	"CanContainContent": false,
 	"IsBetaVersion": false,


### PR DESCRIPTION
- Added support for setting entity to currently compiled blueprint by tracking opened blueprint editors:
I found that VS Code Wakatime plugin sets ``--entity`` to currently edited file so I decided to add this feature to this plugin.
The ``OnBlueprintPreCompile`` event provide UBlueprint class but it was triggering on every blueprint compile, so to fix this I subscribed to ``OnAssetOpened`` and ``OnAssetClosed`` to track what asset is opened and closed so its gonna send heartbeat only for the blueprint that we have opened.
- Redone wakatime-cli check to use unreal native method instead of cli command:
For some reason calling cmd command returns weird exit code, which causes redownloading wakatime-cli even if it already exists.
- Added option for setting custom ``api-url``
This is for all the people that use wakapi. I added the field to plugin window popup, but I think it shouldnt be there and code should grab it from config file.
- Blueprint compiling related heartbeat is now plugged in after editor window is initialized to prevent heartbeat spam during editor startup blueprint compilation
The pre editor window during startup is compiling all blueprints in the project, this caused a lot of heartbeats to be generated, so to fix it code hooks to blueprint events in the ``OnEditorInitialized``.
- Added option to specify Language for the heartbeat to differentiate between editor and blueprint heartbeat
This fixes #41 

Other changes:
Thanks to wakatime-cli log and docs I found out that the only thing to provide git branch info is to add ``--project-folder`` with path to the project so ``FPaths::ProjectDir()`` was enough to add it. Fixes #28 
I changed all hardcoded path ``/`` to ``\\`` becouse cmd has some ``/`` arguments and it was behaving badly with some paths. I also converted all runtime paths to it, but...
...at the end didnt change anything becouse now sending heartbeat softlocks editor so I changed it to powershell and it works now.

Experiments:
I tried wrapping heartbeat into AsyncTask but at that time it was behaving weirdly.
Tried changing ``CreateProcess`` to unreal native method for running external commands/processes but I also run into some issues. Tho it allows to easily check the return code and StdOut/StdErr and automatically waits.

Additional ideas:
I think it will be possible to introduce more tracking of what is edited by adding more asset type checks to ``OnAssetOpened``/``OnAssetClosed`` and hooking into some "OnAssetSave" event?

Im keeping it currently drafted. I want to add grabbing plugin version from uproject before it gets merged to master.